### PR TITLE
fix: nginx log format example

### DIFF
--- a/nginx/how_to_monitor_nginx_with_datadog.md
+++ b/nginx/how_to_monitor_nginx_with_datadog.md
@@ -102,7 +102,8 @@ Datadog will process any log formatted as JSON [automatically](https://docs.data
 ```
     log_format json_custom escape=json
     '{'
-      '"http.version":"$request",'
+      '"http.url":"$request_uri",'
+      '"http.version":"$server_protocol",'
       '"http.status_code":$status,'
       '"http.method":"$request_method",'
       '"http.referer":"$http_referer",'


### PR DESCRIPTION
Prior example would have the HTTP request URL and HTTP version in the `http.version` attribute. That's nonsensical and wrong. This format properly extracts the URL and the HTTP version separately.