### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+
+# Contribution Guidelines
+
+Thanks for taking the time to contribute to Datadog's blog, [The Monitor](https://www.datadoghq.com/blog)! We use this repo to review content updates to our 3-part guides.
+
+There are a few guidelines we'd like contributors to follow when they submit a new issue or pull request (PR).
+
+### Issues
+
+Issues can be used to report broken links, outdated content, or other content issues. As a general rule, issues should include:
+
+- a brief description of the issue
+- a proposed fix with supporting documentation
+  
+**Questions or ideas for a new blog post?** Please do not use issues for pitches or general questions about Datadog. You can [contact support](https://www.datadoghq.com/support/) for any questions about using a particular Datadog feature. 
+
+To help us focus on our guides, we will close all issues that are content pitches or requests for general support and redirect users to our support page where applicable.  
+
+### PRs
+
+Submitting a PR is the best way to fast-track an update to one of our guides. In general, PRs should:
+
+- address a single concern 
+- include a summary of the issue and your motivation for submitting the PR 
+- your proposed changes with supporting documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 
 # Contribution Guidelines
 
-Thanks for taking the time to contribute to Datadog's blog, [The Monitor](https://www.datadoghq.com/blog)! We use this repo to review content updates to our 3-part guides.
+Thanks for taking the time to contribute to Datadog's blog, [The Monitor](https://www.datadoghq.com/blog)! We use this repo to review content updates to our longform guides.
 
 There are a few guidelines we'd like contributors to follow when they submit a new issue or pull request (PR).
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # the-monitor
-Markdown files for Datadog's long-form blog posts: https://www.datadoghq.com/blog/
+Markdown files for Datadog's longform blog posts: https://www.datadoghq.com/blog/
+
+Please read our [contribution guidelines](https://github.com/DataDog/the-monitor/blob/master/CONTRIBUTING.md) before opening a new issue or pull request. 
 


### PR DESCRIPTION
Adds guidelines for submitting new issues and PRs. I also updated our README to include a link to the new file. 

Preview: https://github.com/DataDog/the-monitor/blob/mallory.mooney/contrib-guide/CONTRIBUTING.md

**How does this work?** 
When someone opens a pull request or creates an issue, they will see a link to this new file. 

**Why create one?**
Gives contributors some general rules to follow before submitting an issue/PR and helps direct them to other channels where needed (e.g., our support page).